### PR TITLE
Fix unstage renamed file

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -19,15 +19,15 @@ func UnstageFile(path string) error {
 
 func Diff(opt DiffOption) (string, error) {
 	cmd := newDiffCmd(opt)
-	out, _ := cmd.Output()
-	// if err != nil && !isExitError(err) {
-	// 	return "", err
-	// }
+	out, err := cmd.Output()
+	if err != nil && !isExitError(err) {
+		return "", err
+	}
 	return string(out), nil
 }
 
 func runCommand(cmd *exec.Cmd) error {
-	if err := cmd.Run(); err != nil && isExitError(err) {
+	if err := cmd.Run(); err != nil && !isExitError(err) {
 		return err
 	}
 	return nil

--- a/internal/ui/filelist/item.go
+++ b/internal/ui/filelist/item.go
@@ -7,33 +7,29 @@ import (
 )
 
 type Item struct {
-	FileStatus git.FileStatus
-	Path       string
-	Accessory  string
+	git.FileStatus
+	Accessory string
 }
 
 func (item Item) String() string {
-	if len(item.Accessory) == 0 {
-		return item.Path
+	var path string
+
+	if len(item.FileStatus.Extra) > 0 {
+		path = fmt.Sprintf("%s → %s", item.Path, item.Extra)
+	} else {
+		path = item.Path
 	}
+
+	if len(item.Accessory) == 0 {
+		return path
+	}
+
 	return fmt.Sprintf("%s %s", item.Accessory, item.Path)
 }
 
 func NewItem(fileStatus git.FileStatus) Item {
-	var (
-		path, accessory string
-	)
-
-	path = fileStatus.Path
-	if len(fileStatus.Extra) > 0 {
-		path = fmt.Sprintf("%s → %s", path, fileStatus.Extra)
-	}
-
-	accessory = fmt.Sprintf("[%s]", string(fileStatus.Code))
-
 	return Item{
 		FileStatus: fileStatus,
-		Path:       path,
-		Accessory:  accessory,
+		Accessory:  fmt.Sprintf("[%s]", string(fileStatus.Code)),
 	}
 }


### PR DESCRIPTION
fixes #2  

The file path included the original name of a renamed file. 
Additionally the error was not handled correctly in `runCommand()`.